### PR TITLE
remove webdriver init from install task, it's not needed in production u...

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,8 +34,6 @@ var config = {
 // Package management
 /* Install & update Bower dependencies */
 gulp.task('install', ['config', 'bower'], function() {
-  // Downloads the Selenium webdriver
-  $.protractor.webdriver_update(function() {});
   gulp.start('integrate');
 });
 


### PR DESCRIPTION
no need to init webdrivers with production, init is exists in test:e2e task
