### PR TITLE
Fix WP7 to use polling transport

### DIFF
--- a/src/app/controllers/default-controller.js
+++ b/src/app/controllers/default-controller.js
@@ -1,10 +1,6 @@
 angular.module('DeviceWall')
   .controller('DefaultController', function($scope, $location, $window, $log, Devices, socketConnect, appConfig) {
     'use strict';
-    if (socketConnect === false) {
-      $log.debug("Browser does not support WebSockets");
-      $scope.error = "WebSocket is not supported by your device, therefore you can't use Device Wall with this device.";
-    }
     function redirectToClient() {
       $location.path('/client');
     }

--- a/src/app/services/devicewall-connect.js
+++ b/src/app/services/devicewall-connect.js
@@ -4,13 +4,12 @@
 
   angular.module('DeviceWall')
     .factory('socketConnect', function($log, $window, socketFactory) {
-      if (('WebSocket' in $window) === false) {
-        return false;
-      }
+      // If no WebSocket support or device is WP7, force transport to be polling
+      var options = ('WebSocket' in $window === false || navigator.userAgent.match(/Windows Phone OS 7\.5/)) ? {transports: ["polling"]} : {};
       return {
         connect: function(path) {
           return socketFactory({
-            ioSocket: io.connect(path)
+            ioSocket: io.connect(path, options)
           });
         }
       };


### PR DESCRIPTION
Force transport to be polling if user agent WP7 or WebSocket.