### PR TITLE
Fix to control panel mode from client mode

### DIFF
--- a/src/app/controllers/client-controller.js
+++ b/src/app/controllers/client-controller.js
@@ -1,7 +1,7 @@
 /*jshint -W072 */
 angular.module('DeviceWall')
   .controller('ClientController',
-  function($rootScope, $scope, $timeout, socketConnect, $window, appConfig, Util, $log) {
+  function($rootScope, $scope, $location, $timeout, socketConnect, $window, appConfig, Util, $log) {
     var screensaverTimeoutPromise;
     var screensaverTimeoutSeconds = appConfig.client.screenSaverTimeoutSeconds || 60;
     var socket = socketConnect.connect('/devicewallapp');
@@ -27,10 +27,7 @@ angular.module('DeviceWall')
     };
 
     $scope.showControlPanel = function() {
-      var portString = $window.location.port.length > 0 ? ':' + $window.location.port : '';
-      var url = $window.location.protocol + '//' + $window.location.hostname + portString +
-        '/devices';
-      $window.location.href = url;
+      $location.path('/devices');
     };
 
     socket.on('connect', function() {

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,13 @@
 <html ng-app="DeviceWall">
 <head>
   <base href="/">
+  <!--[if IE]><script type="text/javascript">
+    // Fix for IE ignoring relative base tags.
+    (function() {
+        var baseTag = document.getElementsByTagName('base')[0];
+        baseTag.href = baseTag.href;
+    })();
+  </script><![endif]-->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, user-scalable=no, minimal-ui, initial-scale=1.0">
   <title>Device Wall</title>


### PR DESCRIPTION
Fixes issues with IE9 and other browsers without history.pushState when changing from client mode to control panel mode.