### PR TITLE
Add selected user-agent under accordion title when collapsed

### DIFF
--- a/src/assets/views/main.html
+++ b/src/assets/views/main.html
@@ -46,9 +46,10 @@
         </div>
       </div>
 
-      <section data-ng-show="config.connectionSetup.enabled">
+      <section data-ng-show="config.connectionSetup.enabled" id="connection-setup">
         <div class="section-wrapper accordion collapsed">
         <h2 toggle-accordion>Connection setup</h2>
+        <div class="selected-options" id="connection-setup-selected-options">{{ userAgent.selected.value ? 'User agent: ' + userAgent.selected.value : ''}}</div>
         <div class="connection-setup accordion-content">
           <div data-ng-hide="true" class="checkbox">
             <label>

--- a/src/css/_control_panel.scss
+++ b/src/css/_control_panel.scss
@@ -77,12 +77,27 @@ body {
       background-color: #808080;
     }
 
+    .selected-options {
+      display: none;
+    }
+
     &.collapsed {
       overflow: hidden;
-      max-height: 30px;
+
+      h2 {
+        margin-bottom: 0;
+      }
 
       h2:before {
         content: '\e825';
+      }
+
+      .accordion-content {
+        display: none;
+      }
+
+      .selected-options {
+        display: block;
       }
     }
   }

--- a/tests/e2e/control-panel/control-panel.js
+++ b/tests/e2e/control-panel/control-panel.js
@@ -78,7 +78,7 @@ describe('Control panel', function() {
     expect(element(by.id('go-button')).isEnabled()).to.eventually.equal(true);
   });
 
-  it('should set url value to http://www when clicked', function() {
+  it('should set url value to http:// when clicked', function() {
     element(by.id('url_value')).click();
     expect(element(by.id('url_value')).getAttribute('value')).to.eventually.equal('http://');
   });
@@ -206,5 +206,14 @@ describe('Control panel', function() {
     expect(element(by.css('#devices-list input[data-ng-model="device.model"]')).getAttribute('value')).to.eventually.equal('iPhone');
     expect(element(by.css('#devices-list input[data-ng-model="device.platform"]')).getAttribute('value')).to.eventually.equal('iOS');
     expect(element(by.css('#devices-list input[data-ng-model="device.version"]')).getAttribute('value')).to.eventually.equal('6.1');
+  });
+
+  it('should show selected user agent under heading when accordion collapsed', function() {
+    element(by.css('#connection-setup h2')).click();
+    element(by.cssContainingText('option', 'desktop (OS X)')).click();
+    expect(element(by.css("#connection-setup-selected-options")).getText()).to.eventually.equal('');
+    element(by.css('#connection-setup h2')).click();
+    expect(element(by.css("#connection-setup .accordion-content")).isDisplayed()).to.eventually.equal(false);
+    expect(element(by.css("#connection-setup-selected-options")).getText()).to.eventually.contain("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.124 Safari/537.36");
   });
 });


### PR DESCRIPTION
If user agent is selected (userAgent.selected.value has something), show it under Connection setup header when accordion is collapsed.