### PR TITLE
Fix duplicate labels on control panel when renaming

### DIFF
--- a/src/app/controllers/main-controller.js
+++ b/src/app/controllers/main-controller.js
@@ -181,8 +181,12 @@ angular.module('DeviceWall')
         if (DeviceList.has({label: data.oldLabel})) {
           var device = DeviceList.get(data.oldLabel);
           DeviceList.remove(device);
+          if (DeviceList.has({label: data.newLabel})) {
+            DeviceList.remove(DeviceList.get(data.newLabel));
+          }
           device.label = data.newLabel;
           DeviceList.add(device);
+          $scope.deviceList = DeviceList.toArray();
         }
       });
       socket.on('update', function (data) {


### PR DESCRIPTION
If after renaming there are two devices with same label, control panel will show only one row for the device.